### PR TITLE
fix: add missing enummember token

### DIFF
--- a/themes/bluloco-light-color-theme.json
+++ b/themes/bluloco-light-color-theme.json
@@ -485,6 +485,7 @@
         "entity.other.inherited-class",
         "entity.name.type",
         "variable.other.constant.elixir",
+        "variable.other.enummember",
         "storage.type.haskell",
         "support.type.graphql",
         "support.type.enum.graphql"

--- a/themes/bluloco-light-italic-color-theme.json
+++ b/themes/bluloco-light-italic-color-theme.json
@@ -484,6 +484,7 @@
         "entity.other.inherited-class",
         "entity.name.type",
         "variable.other.constant.elixir",
+        "variable.other.enummember",
         "storage.type.haskell",
         "support.type.graphql",
         "support.type.enum.graphql"


### PR DESCRIPTION
For rust-analyzer, result using token `variable.other.enummember`.
But the theme not include this token, then it fallback to variable `#383a42`.

Disable rust-analyzer:
![Screenshot from 2021-07-22 11-25-18](https://user-images.githubusercontent.com/3736910/126586193-fbf85eb3-ee44-4616-9408-d3c920af8ef8.png)

Enable rust-analyzer:
![Screenshot from 2021-07-22 11-25-45](https://user-images.githubusercontent.com/3736910/126586210-96b2542d-a65d-49b0-897b-698ba3198619.png)
